### PR TITLE
Fix indentation of the code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::thread;
 
 fn main() {
-	let db_url =  "mysql://root:12345678@localhost:3306/test";
+    let db_url =  "mysql://root:12345678@localhost:3306/test";
     let config = r2d2::config::Builder::new().pool_size(5).build();   // r2d2::Config::default()
     let manager = r2d2_mysql::MysqlConnectionManager::new(db_url).unwrap();
     let pool = Arc::new(r2d2::Pool::new(config, manager).unwrap());


### PR DESCRIPTION
There was a tab instead of four spaces, which broke the formatting in some viewers/editors:

![indentation](https://user-images.githubusercontent.com/5675953/48302839-29df5e80-e502-11e8-8200-ce24f5ab8dd2.png)
