### PR TITLE
clean up readme and example code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "http://outersky.github.io/r2d2-mysql/doc/v0.2.0/r2d2_mysql"
 description = "MySQL support for the r2d2 connection pool"
 repository = "https://github.com/outersky/r2d2-mysql"
 keywords = ["mysql", "sql", "pool", "database", "r2d2"]
+edition = "2018"
 
 [dependencies]
 r2d2 = "0.8.9"

--- a/README.md
+++ b/README.md
@@ -1,55 +1,47 @@
 # r2d2-mysql
-[`rust-mysql-simple`](https://github.com/blackbeam/rust-mysql-simple) support library for the [`r2d2`](https://github.com/sfackler/r2d2) connection pool.
-Documentation is available at [http://outersky.github.io/r2d2-mysql/doc/v3.0.0/r2d2_mysql](http://outersky.github.io/r2d2-mysql/doc/v3.0.0/r2d2_mysql)
 
-#### Install
-Just include another `[dependencies]` section into your Cargo.toml:
+> [`rust-mysql-simple`](https://github.com/blackbeam/rust-mysql-simple) support library for the [`r2d2`](https://github.com/sfackler/r2d2) connection pool.
+
+Documentation is available at <http://docs.rs/r2d2_mysql>.
+
+## Install
+
+Include `r2d2_mysql` in the `[dependencies]` section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-r2d2_mysql="*"
+r2d2_mysql = "22"
 ```
-#### Example
 
-```rust,no_run
-extern crate mysql;
-extern crate r2d2_mysql;
-extern crate r2d2;
+## Usage
 
-use std::env;
-use std::sync::Arc;
-use std::thread;
-use mysql::{Opts,OptsBuilder};
-use mysql::prelude::Queryable;
+```rust
+use std::{env, sync::Arc, thread};
+use mysql::{prelude::*, Opts, OptsBuilder};
 use r2d2_mysql::MysqlConnectionManager;
 
 fn main() {
-	let url = env::var("DATABASE_URL").unwrap();
-        let opts = Opts::from_url(&url).unwrap();
-        let builder = OptsBuilder::from_opts(opts);
-        let manager = MysqlConnectionManager::new(builder);
-        let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
+    let url = env::var("DATABASE_URL").unwrap();
+    let opts = Opts::from_url(&url).unwrap();
+    let builder = OptsBuilder::from_opts(opts);
+    let manager = MysqlConnectionManager::new(builder);
+    let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
 
-        let mut tasks = vec![];
+    let mut tasks = vec![];
 
-        for _ in 0..3 {
-            let pool = pool.clone();
-            let th = thread::spawn(move || {
-                let mut conn = pool.get()
-                    .map_err(|err| {
-                        println!(
-                            "get connection from pool error in line:{} ! error: {:?}",
-                            line!(),
-                            err
-                        )
-                    })
-                    .unwrap();
-                let _ = conn.query("SELECT version()").map(|_: Vec<String>| ()).map_err(|err| {
-                    println!("execute query error in line:{} ! error: {:?}", line!(), err)
-                });
-            });
-            tasks.push(th);
-        }
+    for _ in 0..3 {
+        let pool = pool.clone();
+        let th = thread::spawn(move || {
+            let mut conn = pool.get().expect("error getting connection from pool");
+
+            let _ = conn
+                .query("SELECT version()")
+                .map(|rows: Vec<String>| rows.is_empty())
+                .expect("error executing query");
+        });
+
+        tasks.push(th);
+    }
 
     for th in tasks {
         let _ = th.join();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,82 +1,47 @@
-//! # r2d2-mysql
-//! MySQL support for the r2d2 connection pool (Rust) . see [`r2d2`](http://github.com/sfackler/r2d2.git)  .
+//! MySQL support for the [`r2d2`] connection pool (Rust).
 //!
-//! #### Install
-//! Just include another `[dependencies.*]` section into your Cargo.toml:
-//!
-//! ```toml
-//! [dependencies.r2d2_mysql]
-//! git = "https://github.com/outersky/r2d2-mysql"
-//! version="*"
+//! # Examples
 //! ```
-//! #### Sample
-//!
-//! ```
-//! extern crate mysql;
-//! extern crate r2d2_mysql;
-//! extern crate r2d2;
-//!
-//! use std::env;
-//! use std::sync::Arc;
-//! use std::thread;
-//! use mysql::{Opts,OptsBuilder};
-//! use mysql::prelude::Queryable;
+//! use std::{env, sync::Arc, thread};
+//! use mysql::{prelude::*, Opts, OptsBuilder};
 //! use r2d2_mysql::MysqlConnectionManager;
 //!
-//! fn main() {
-//! 	let url = env::var("DATABASE_URL").unwrap();
-//!         let opts = Opts::from_url(&url).unwrap();
-//!         let builder = OptsBuilder::from_opts(opts);
-//!         let manager = MysqlConnectionManager::new(builder);
-//!         let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
+//! let url = env::var("DATABASE_URL").unwrap();
+//! let opts = Opts::from_url(&url).unwrap();
+//! let builder = OptsBuilder::from_opts(opts);
+//! let manager = MysqlConnectionManager::new(builder);
+//! let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
 //!
-//!         let mut tasks = vec![];
+//! let mut tasks = vec![];
 //!
-//!         for _ in 0..3 {
-//!             let pool = pool.clone();
-//!             let th = thread::spawn(move || {
-//!                 let mut conn = pool.get()
-//!                     .map_err(|err| {
-//!                         println!(
-//!                             "get connection from pool error in line:{} ! error: {:?}",
-//!                             line!(),
-//!                             err
-//!                         )
-//!                     })
-//!                     .unwrap();
-//!                 let _ = conn.query("SELECT version()").map(|_: Vec<String>| ()).map_err(|err| {
-//!                     println!("execute query error in line:{} ! error: {:?}", line!(), err)
-//!                 });
-//!             });
-//!             tasks.push(th);
-//!         }
+//! for _ in 0..3 {
+//!     let pool = pool.clone();
+//!     let th = thread::spawn(move || {
+//!         let mut conn = pool.get().expect("error getting connection from pool");
 //!
-//!     for th in tasks {
-//!         let _ = th.join();
-//!     }
+//!         let _ = conn
+//!             .query("SELECT version()")
+//!             .map(|rows: Vec<String>| rows.is_empty())
+//!             .expect("error executing query");
+//!     });
+//!
+//!     tasks.push(th);
+//! }
+//!
+//! for th in tasks {
+//!     let _ = th.join();
 //! }
 //! ```
-//!
-
-#![doc(html_root_url = "http://outersky.github.io/r2d2-mysql/doc/v0.2.0/r2d2_mysql/")]
-#![crate_name = "r2d2_mysql"]
-#![crate_type = "rlib"]
-#![crate_type = "dylib"]
-
-pub extern crate mysql;
-pub extern crate r2d2;
 
 pub mod pool;
 pub use pool::MysqlConnectionManager;
 
 #[cfg(test)]
 mod test {
-    use mysql::{Opts, OptsBuilder};
-    use mysql::prelude::Queryable;
-    use r2d2;
-    use std::env;
-    use std::sync::Arc;
-    use std::thread;
+    use std::{env, sync::Arc, thread};
+
+    use mysql::{prelude::*, Opts, OptsBuilder};
+
     use super::MysqlConnectionManager;
 
     #[test]
@@ -92,19 +57,14 @@ mod test {
         for _ in 0..3 {
             let pool = pool.clone();
             let th = thread::spawn(move || {
-                let mut conn = pool.get()
-                    .map_err(|err| {
-                        println!(
-                            "get connection from pool error in line:{} ! error: {:?}",
-                            line!(),
-                            err
-                        )
-                    })
-                    .unwrap();
-                let _ = conn.query("SELECT version()").map(|_: Vec<String>| ()).map_err(|err| {
-                    println!("execute query error in line:{} ! error: {:?}", line!(), err)
-                });
+                let mut conn = pool.get().expect("error getting connection from pool");
+
+                let _ = conn
+                    .query("SELECT version()")
+                    .map(|rows: Vec<String>| rows.is_empty())
+                    .expect("error executing query");
             });
+
             tasks.push(th);
         }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,8 +1,5 @@
-use mysql::error::Error;
-use mysql::{Conn, Opts, OptsBuilder};
-use std::result::Result;
-use r2d2;
-use mysql::prelude::Queryable;
+use mysql::prelude::*;
+use mysql::{error::Error, Conn, Opts, OptsBuilder};
 
 #[derive(Clone, Debug)]
 pub struct MysqlConnectionManager {


### PR DESCRIPTION
- use more concise .expect error handling
- combine imports
- remove unnecessary extern crate statements
- indicate where rows are accessible
- return non-unit from query
- rustfmt code
- don't use "*" as version recommendation
- point to docs.rs docs