### PR TITLE
update mysql dependency to 23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "r2d2_mysql"
-version = "22.0.0"
+version = "23.0.0"
 authors = ["outersky <outersky@gmail.com>"]
 license = "MIT"
-documentation = "http://outersky.github.io/r2d2-mysql/doc/v0.2.0/r2d2_mysql"
 description = "MySQL support for the r2d2 connection pool"
-repository = "https://github.com/outersky/r2d2-mysql"
+repository = "https://github.com/outersky/r2d2-mysql.git"
 keywords = ["mysql", "sql", "pool", "database", "r2d2"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Include `r2d2_mysql` in the `[dependencies]` section of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-r2d2_mysql = "22"
+r2d2_mysql = "23"
 ```
 
 ## Usage
@@ -18,13 +18,13 @@ r2d2_mysql = "22"
 ```rust
 use std::{env, sync::Arc, thread};
 use mysql::{prelude::*, Opts, OptsBuilder};
-use r2d2_mysql::MysqlConnectionManager;
+use r2d2_mysql::MySqlConnectionManager;
 
 fn main() {
     let url = env::var("DATABASE_URL").unwrap();
     let opts = Opts::from_url(&url).unwrap();
     let builder = OptsBuilder::from_opts(opts);
-    let manager = MysqlConnectionManager::new(builder);
+    let manager = MySqlConnectionManager::new(builder);
     let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
 
     let mut tasks = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,12 @@
 //! ```
 //! use std::{env, sync::Arc, thread};
 //! use mysql::{prelude::*, Opts, OptsBuilder};
-//! use r2d2_mysql::MysqlConnectionManager;
+//! use r2d2_mysql::MySqlConnectionManager;
 //!
 //! let url = env::var("DATABASE_URL").unwrap();
 //! let opts = Opts::from_url(&url).unwrap();
 //! let builder = OptsBuilder::from_opts(opts);
-//! let manager = MysqlConnectionManager::new(builder);
+//! let manager = MySqlConnectionManager::new(builder);
 //! let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
 //!
 //! let mut tasks = vec![];
@@ -33,8 +33,10 @@
 //! }
 //! ```
 
-pub mod pool;
-pub use pool::MysqlConnectionManager;
+mod pool;
+pub use self::pool::MySqlConnectionManager;
+#[allow(deprecated)]
+pub use self::pool::MysqlConnectionManager;
 
 #[cfg(test)]
 mod test {
@@ -42,14 +44,14 @@ mod test {
 
     use mysql::{prelude::*, Opts, OptsBuilder};
 
-    use super::MysqlConnectionManager;
+    use super::MySqlConnectionManager;
 
     #[test]
     fn query_pool() {
         let url = env::var("DATABASE_URL").unwrap();
         let opts = Opts::from_url(&url).unwrap();
         let builder = OptsBuilder::from_opts(opts);
-        let manager = MysqlConnectionManager::new(builder);
+        let manager = MySqlConnectionManager::new(builder);
         let pool = Arc::new(r2d2::Pool::builder().max_size(4).build(manager).unwrap());
 
         let mut tasks = vec![];

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,20 +1,29 @@
-use mysql::prelude::*;
-use mysql::{error::Error, Conn, Opts, OptsBuilder};
+//! Connection manager implementation for MySQL connections.
+//!
+//! See [`MySqlConnectionManager`].
 
+use mysql::{error::Error, prelude::*, Conn, Opts, OptsBuilder};
+
+#[doc(hidden)]
+#[deprecated(since = "23.0.0", note = "Renamed to `MySqlConnectionManager`.")]
+pub type MysqlConnectionManager = MySqlConnectionManager;
+
+/// An [`r2d2`] connection manager for [`mysql`] connections.
 #[derive(Clone, Debug)]
-pub struct MysqlConnectionManager {
+pub struct MySqlConnectionManager {
     params: Opts,
 }
 
-impl MysqlConnectionManager {
-    pub fn new(params: OptsBuilder) -> MysqlConnectionManager {
-        MysqlConnectionManager {
+impl MySqlConnectionManager {
+    /// Constructs a new MySQL connection manager from `params`.
+    pub fn new(params: OptsBuilder) -> MySqlConnectionManager {
+        MySqlConnectionManager {
             params: Opts::from(params),
         }
     }
 }
 
-impl r2d2::ManageConnection for MysqlConnectionManager {
+impl r2d2::ManageConnection for MySqlConnectionManager {
     type Connection = Conn;
     type Error = Error;
 


### PR DESCRIPTION
- bump `r2d2_mysql` version to `23.0.0`
- rename `MysqlConnectionManager => MySqlConnectionManager`
  - this is more in line with `mysql` crate and rust conventions
- add deprecated alias to old name for compatability
- hide `pool` module since it provides no extra types
- document public items