### PR TITLE
chore: update MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,18 +11,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [1.65.0, stable, nightly]
+        version:
+          - { name: msrv, version: 1.68.0 }
+          - { name: stable, version: stable }
+          - { name: nightly, version: nightly }
 
-    name: tests / ${{ matrix.version }}
+    name: tests / ${{ matrix.version.name }}
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Rust
+      - name: Install Rust (${{ matrix.version.name }})
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
         with:
-          toolchain: ${{ matrix.version }}
+          toolchain: ${{ matrix.version.version }}
 
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minimum supported Rust version (MSRV) is now 1.68 due to transitive `time` dependency.
+
 ## 24.0.0
 
 - Update `mysql` dependency to `24`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "MySQL support for the r2d2 connection pool"
 repository = "https://github.com/outersky/r2d2-mysql.git"
 keywords = ["mysql", "sql", "pool", "database", "r2d2"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.68"
 
 [dependencies]
 r2d2 = "0.8.9"


### PR DESCRIPTION
bumps MSRV as described

also makes the CI setup a bit more stable by making the job names stable across MSRV updates

no release needed for this one