### PR TITLE
feat: update mysql dep to 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - { name: msrv, version: 1.70.0 }
+          - { name: msrv, version: 1.81.0 }
           - { name: stable, version: stable }
           - { name: nightly, version: nightly }
 
@@ -30,8 +30,13 @@ jobs:
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:
-          mysql user: 'ci'
-          mysql password: 'ci'
+          mysql user: "ci"
+          mysql password: "ci"
+
+      - name: downgrades for MSRV
+        if: matrix.version.name == 'msrv'
+        run: |
+          cargo update -p=idna_adapter --precise=1.2.0 # next ver: 1.82.0
 
       - run: cargo test
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 26.0.0
+
+- Update `mysql` dependency to `26`.
+- Minimum supported Rust version (MSRV) is now 1.81 to align with `mysql` dependency.
+
 ## 25.0.0
 
 - Update `mysql` dependency to `25`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "r2d2_mysql"
-version = "25.0.0"
+version = "26.0.0"
 authors = ["outersky <outersky@gmail.com>"]
 license = "MIT"
 description = "MySQL support for the r2d2 connection pool"
 repository = "https://github.com/outersky/r2d2-mysql"
 keywords = ["mysql", "sql", "pool", "database", "r2d2"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.81"
 
 [dependencies]
 r2d2 = "0.8.9"
-mysql = "25"
+mysql = { version = "26", default-features = false, features = ["minimal"] }


### PR DESCRIPTION
msrv update is required by way of (at least) `mysql`'s `twox-hash` dependency

changelog and manifest have updated versions so that a release can be published immediately after merge, with your blessing @outersky

GH release also ready: https://github.com/outersky/r2d2-mysql/releases/tag/untagged-ee958421ca3dda125b1a